### PR TITLE
#259 PHP noticeへの対応 2

### DIFF
--- a/qa-cat-desc-layer.php
+++ b/qa-cat-desc-layer.php
@@ -7,7 +7,9 @@ class qa_html_theme_layer extends qa_html_theme_base
 		$categoryslug = '';
 		if ($this->template === 'questions') {
 			$requests = explode('/', $this->request);
-			$categoryslug = $requests[1];
+			if (isset($requests[1])) {
+				$categoryslug = $requests[1];
+			}
 		} elseif ($this->template === 'qa') {
 			$categoryslug = $this->request;
 		}

--- a/qa-cat-desc-widget.php
+++ b/qa-cat-desc-widget.php
@@ -18,7 +18,12 @@ class qa_cat_descriptions_widget {
 
 		if ($template === 'questions') {
 			$parts=explode('/', $request);
-			$categoryslugs = $parts[1];
+			if (isset($parts[1])) {
+				$categoryslugs = $parts[1];
+			} else {
+				$categoryslugs = '';
+			}
+			
 		} elseif ($template === 'qa') {
 			$categoryslugs = $request;
 		}


### PR DESCRIPTION
- categoryslug  を取得するとき url にカテゴリが含まれていない場合、$requests[1] や $parts[1] は存在しないが、アクセスしようとして notice が出ていたので修正
